### PR TITLE
Curl mbedtls

### DIFF
--- a/ports/curl/0005_mbedtls.patch
+++ b/ports/curl/0005_mbedtls.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/vtls/mbedtls.c b/lib/vtls/mbedtls.c
+index d7759dc84..c862f744a 100644
+--- a/lib/vtls/mbedtls.c
++++ b/lib/vtls/mbedtls.c
+@@ -577,6 +577,8 @@ mbed_connect_step2(struct connectdata *conn,
+ 
+   ret = mbedtls_ssl_get_verify_result(&BACKEND->ssl);
+ 
++  if(!SSL_CONN_CONFIG(verifyhost))
++    ret &= ~MBEDTLS_X509_BADCERT_CN_MISMATCH;   /* Ignore hostname errors */
+   if(ret && SSL_CONN_CONFIG(verifypeer)) {
+     if(ret & MBEDTLS_X509_BADCERT_EXPIRED)
+       failf(data, "Cert verify failed: BADCERT_EXPIRED");

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         0002_fix_uwp.patch
         0003_fix_libraries.patch
         0004_nghttp2_staticlib.patch
+        0005_mbedtls.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)

--- a/ports/minizip/minizip.patch
+++ b/ports/minizip/minizip.patch
@@ -1,0 +1,16 @@
+diff --git a/contrib/minizip/unzip.c b/contrib/minizip/unzip.c
+index f12e3329..bfc05f77 100644
+--- a/contrib/minizip/unzip.c
++++ b/contrib/minizip/unzip.c
+@@ -68,10 +68,6 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-#ifndef NOUNCRYPT
+-        #define NOUNCRYPT
+-#endif
+-
+ #include "zlib.h"
+ #include "unzip.h"
+ 
+

--- a/ports/minizip/portfile.cmake
+++ b/ports/minizip/portfile.cmake
@@ -12,6 +12,11 @@ vcpkg_from_github(
   HEAD_REF master
 )
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/minizip.patch)
+
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Fixes a bug in the certificate verification settings when using `mbedTLS`. There's an active PR in the Curl repo so eventually this vcpkg patch won't be needed.